### PR TITLE
Restored types to vanilla docs template

### DIFF
--- a/template-vanilla/tmpl/members.tmpl
+++ b/template-vanilla/tmpl/members.tmpl
@@ -17,6 +17,15 @@ var self = this;
     </div>
     <?js } ?>
 
+    <?js if (data && data.type && data.type.names) {?>
+        <h5>Type:</h5>
+        <ul>
+            <li>
+                <?js= self.partial('type.tmpl', data.type.names) ?>
+            </li>
+        </ul>
+    <?js } ?>
+
     <?js= this.partial('details.tmpl', data) ?>
 
     <?js if (data.examples && examples.length) { ?>


### PR DESCRIPTION
Added data types to the documentation template for documenting properties that can be initialized via annotation initializers.

![image](https://user-images.githubusercontent.com/25498512/120420276-f01d1000-c318-11eb-8135-c6aee964124f.png)
