### PR TITLE
[Bugfix] Dropdown Nav elements creates 404

### DIFF
--- a/template-algolia/publish.js
+++ b/template-algolia/publish.js
@@ -64,7 +64,7 @@ var navigationMaster = {
   },
   namespace: {
     title: "Namespaces",
-    link: helper.getUniqueFilename("namespaces.list"),
+    // link: helper.getUniqueFilename("namespaces.list"),
     members: []
   },
   module: {

--- a/template-algolia/static/styles/site.pdftron.css
+++ b/template-algolia/static/styles/site.pdftron.css
@@ -1075,9 +1075,10 @@ body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
-  background-color: #FCFCFC;
-}
+  color: #000;
+  background-color: #fcfcfc;
+} 
+
 input,
 button,
 select,
@@ -1087,8 +1088,12 @@ textarea {
   line-height: inherit;
 }
 a {
-  color: #00a5e4;
+  color: #0206A8;
   text-decoration: none;
+}
+.subsection-title {
+  font-weight: 600;
+  color:#00083D;
 }
 a:hover,
 a:focus {
@@ -1177,7 +1182,7 @@ h6,
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 300;
   line-height: 1.1;
-  color: #444;
+  color: #000;
 }
 h1 small,
 h2 small,
@@ -1328,7 +1333,7 @@ mark,
   color: #808080;
 }
 .text-primary {
-  color: #00a5e4;
+  color: #0206a8;
 }
 a.text-primary:hover,
 a.text-primary:focus {
@@ -1364,7 +1369,7 @@ a.text-danger:focus {
 }
 .bg-primary {
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 a.bg-primary:hover,
 a.bg-primary:focus {
@@ -1553,7 +1558,7 @@ pre {
   line-height: 1.42857143;
   word-break: break-all;
   word-wrap: break-word;
-  color: #444;
+  color: #000;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -2490,7 +2495,7 @@ legend {
   margin-bottom: 18px;
   font-size: 19.5px;
   line-height: inherit;
-  color: #777;
+  color: #000;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
@@ -2534,7 +2539,7 @@ output {
   padding-top: 9px;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
+  color: #000;
 }
 .form-control {
   display: block;
@@ -2543,7 +2548,7 @@ output {
   padding: 8px 12px;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
+  color: #000;
   background-color: #fff;
   background-image: none;
   border: 1px solid #ddd;
@@ -3048,26 +3053,26 @@ fieldset[disabled] a.btn {
 }
 .btn-default {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:focus,
 .btn-default.focus {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:hover {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,
@@ -3079,8 +3084,8 @@ fieldset[disabled] a.btn {
 .btn-default.active.focus,
 .open > .dropdown-toggle.btn-default.focus {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active,
 .btn-default.active,
@@ -3105,8 +3110,8 @@ fieldset[disabled] .btn-default.focus {
 }
 .btn-primary {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-primary:focus,
 .btn-primary.focus {
@@ -3153,11 +3158,11 @@ fieldset[disabled] .btn-primary:focus,
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 fieldset[disabled] .btn-primary.focus {
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-primary .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .btn-success {
@@ -3389,7 +3394,7 @@ fieldset[disabled] .btn-danger.focus {
   background-color: #fff;
 }
 .btn-link {
-  color: #00a5e4;
+  color: #0206a8;
   font-weight: normal;
   border-radius: 0;
 }
@@ -3541,14 +3546,14 @@ tbody.collapse.in {
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;
-  color: #444;
+  color: #000;
   white-space: nowrap;
 }
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   text-decoration: none;
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
@@ -3556,7 +3561,7 @@ tbody.collapse.in {
   color: #fff;
   text-decoration: none;
   outline: 0;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
@@ -3801,7 +3806,7 @@ tbody.collapse.in {
 }
 .input-group {
   position: relative;
-  display: flex;
+  display: table;
   border-collapse: separate;
 }
 .input-group[class*="col-"] {
@@ -3879,14 +3884,14 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .input-group-btn {
   width: 1%;
   white-space: nowrap;
-  vertical-align: top;
+  vertical-align: middle;
 }
 .input-group-addon {
   padding: 8px 12px;
   font-size: 13px;
   font-weight: normal;
   line-height: 1;
-  color: #777;
+  color: #000;
   text-align: center;
   background-color: #ddd;
   border: 1px solid #ddd;
@@ -3906,7 +3911,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .input-group-addon input[type="checkbox"] {
   margin-top: 0;
 }
-/* .input-group .form-control:first-child,
+.input-group .form-control:first-child,
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
 .input-group-btn:first-child > .btn-group > .btn,
@@ -3915,7 +3920,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
-} */
+}
 .input-group-addon:first-child {
   border-right: 0;
 }
@@ -3990,7 +3995,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav .open > a:hover,
 .nav .open > a:focus {
   background-color: #ddd;
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .nav .nav-divider {
   height: 1px;
@@ -4020,7 +4025,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
-  color: #777;
+  color: #000;
   background-color: #FCFCFC;
   border: 1px solid #ddd;
   border-bottom-color: transparent;
@@ -4083,7 +4088,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .nav-stacked > li {
   float: none;
@@ -4261,6 +4266,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   font-size: 17px;
   line-height: 18px;
   height: 40px;
+  text-decoration: none;
 }
 .navbar-brand:hover,
 .navbar-brand:focus {
@@ -4373,7 +4379,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     display: inline-block;
   }
   .navbar-form .input-group {
-    display: flex;
+    display: inline-table;
     vertical-align: middle;
   }
   .navbar-form .input-group .input-group-addon,
@@ -4480,34 +4486,34 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-color: #eeeeee;
 }
 .navbar-default .navbar-brand {
-  color: #777;
+  color: #0206a8;
 }
 .navbar-default .navbar-brand:hover,
 .navbar-default .navbar-brand:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-text {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-nav > li > a {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-nav > .disabled > a,
 .navbar-default .navbar-nav > .disabled > a:hover,
 .navbar-default .navbar-nav > .disabled > a:focus {
-  color: #444;
+  color: #000;
   background-color: transparent;
 }
 .navbar-default .navbar-toggle {
@@ -4528,51 +4534,51 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-default .navbar-nav > .open > a:hover,
 .navbar-default .navbar-nav > .open > a:focus {
   background-color: transparent;
-  color: #00a5e4;
+  color: #0206a8;
 }
 @media (max-width: 767px) {
   .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-    color: #777;
+    color: #000;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-    color: #00a5e4;
+    color: #0206a8;
     background-color: transparent;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
-    color: #00a5e4;
+    color: #0206a8;
     background-color: transparent;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
-    color: #444;
+    color: #000;
     background-color: transparent;
   }
 }
 .navbar-default .navbar-link {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-link:hover {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .navbar-default .btn-link {
-  color: #777;
+  color: #000;
 }
 .navbar-default .btn-link:hover,
 .navbar-default .btn-link:focus {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .navbar-default .btn-link[disabled]:hover,
 fieldset[disabled] .navbar-default .btn-link:hover,
 .navbar-default .btn-link[disabled]:focus,
 fieldset[disabled] .navbar-default .btn-link:focus {
-  color: #444;
+  color: #000;
 }
 .navbar-inverse {
-  background-color: #00a5e4;
+  background-color: #0206a8;
   border-color: #a91b0c;
 }
 .navbar-inverse .navbar-brand {
@@ -4707,7 +4713,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   padding: 8px 12px;
   line-height: 1.42857143;
   text-decoration: none;
-  color: #444;
+  color: #000;
   background-color: #fff;
   border: 1px solid #ddd;
   margin-left: -1px;
@@ -4729,8 +4735,8 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > li > span:focus {
   z-index: 2;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .pagination > .active > a,
 .pagination > .active > span,
@@ -4740,8 +4746,8 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > .active > span:focus {
   z-index: 3;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
   cursor: default;
 }
 .pagination > .disabled > span,
@@ -4807,7 +4813,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pager li > a:hover,
 .pager li > a:focus {
   text-decoration: none;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .pager .next > a,
 .pager .next > span {
@@ -4858,7 +4864,7 @@ a.label:focus {
   background-color: #2e2f2f;
 }
 .label-primary {
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .label-primary[href]:hover,
 .label-primary[href]:focus {
@@ -4903,7 +4909,7 @@ a.label:focus {
   vertical-align: middle;
   white-space: nowrap;
   text-align: center;
-  background-color: #00a5e4;
+  background-color: #0206a8;
   border-radius: 10px;
 }
 .badge:empty {
@@ -4926,7 +4932,7 @@ a.badge:focus {
 }
 .list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .list-group-item > .badge {
@@ -5001,11 +5007,11 @@ a.badge:focus {
 a.thumbnail:hover,
 a.thumbnail:focus,
 a.thumbnail.active {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .thumbnail .caption {
   padding: 9px;
-  color: #777;
+  color: #000;
 }
 .alert {
   padding: 15px;
@@ -5115,7 +5121,7 @@ a.thumbnail.active {
   line-height: 18px;
   color: #fff;
   text-align: center;
-  background-color: #00a5e4;
+  background-color: #0206a8;
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   -webkit-transition: width 0.6s ease;
@@ -5238,7 +5244,7 @@ a.thumbnail.active {
 }
 a.list-group-item,
 button.list-group-item {
-  color: #555;
+  color: #000;
 }
 a.list-group-item .list-group-item-heading,
 button.list-group-item .list-group-item-heading {
@@ -5249,7 +5255,7 @@ button.list-group-item:hover,
 a.list-group-item:focus,
 button.list-group-item:focus {
   text-decoration: none;
-  color: #555;
+  color: #000;
   background-color: #f5f5f5;
 }
 button.list-group-item {
@@ -5278,8 +5284,8 @@ button.list-group-item {
 .list-group-item.active:focus {
   z-index: 2;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .list-group-item.active .list-group-item-heading,
 .list-group-item.active:hover .list-group-item-heading,
@@ -5660,7 +5666,7 @@ button.list-group-item-danger.active:focus {
   border-color: #ddd;
 }
 .panel-default > .panel-heading {
-  color: #444;
+  color: #000;
   background-color: #FCFCFC;
   border-color: #ddd;
 }
@@ -5669,28 +5675,28 @@ button.list-group-item-danger.active:focus {
 }
 .panel-default > .panel-heading .badge {
   color: #FCFCFC;
-  background-color: #444;
+  background-color: #000;
 }
 .panel-default > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #ddd;
 }
 .panel-primary {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .panel-primary > .panel-heading {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .panel-primary > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #00a5e4;
+  border-top-color: #0206a8;
 }
 .panel-primary > .panel-heading .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .panel-primary > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #00a5e4;
+  border-bottom-color: #0206a8;
 }
 .panel-success {
   border-color: #469408;
@@ -6727,7 +6733,7 @@ button.close {
 }
 .navbar-inverse .badge {
   background-color: #fff;
-  color: #00a5e4;
+  color: #0206a8;
 }
 .btn {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -6744,9 +6750,9 @@ button.close {
 }
 .btn-primary,
 .btn-primary:hover {
-  background-image: -webkit-linear-gradient(#e72510, #00a5e4 6%, #cb210e);
-  background-image: -o-linear-gradient(#e72510, #00a5e4 6%, #cb210e);
-  background-image: linear-gradient(#e72510, #00a5e4 6%, #cb210e);
+  background-image: -webkit-linear-gradient(#e72510, #0206a8 6%, #cb210e);
+  background-image: -o-linear-gradient(#e72510, #0206a8 6%, #cb210e);
+  background-image: linear-gradient(#e72510, #0206a8 6%, #cb210e);
   background-repeat: no-repeat;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe72510', endColorstr='#ffcb210e', GradientType=0);
   filter: none;
@@ -6796,10 +6802,10 @@ body {
   font-weight: 200;
 }
 th {
-  color: #444;
+  color: #000;
 }
 legend {
-  color: #444;
+  color: #000;
 }
 label {
   font-weight: normal;
@@ -6832,11 +6838,11 @@ label {
 .has-error.radio-inline label,
 .has-error.checkbox-inline label,
 .has-error .form-control-feedback {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .has-error .form-control,
 .has-error .form-control:focus {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .has-success .help-block,
 .has-success .control-label,
@@ -6856,11 +6862,11 @@ label {
   border-color: #469408;
 }
 .pager a {
-  color: #444;
+  color: #000;
 }
 .pager a:hover,
 .pager .active > a {
-  border-color: #00a5e4;
+  border-color: #0206a8;
   color: #fff;
 }
 .pager .disabled > a {
@@ -6907,20 +6913,20 @@ img.branding-logo {
 .copyright {
   font-size: 90%;
   text-align: center;
-  color: #00a5e4;
+  color: #0206a8;
   width: 100%;
   display: block;
 }
 .jsdoc-message {
   font-size: 90%;
   text-align: center;
-  color: #00a5e4;
+  color: #0206a8;
   width: 100%;
   display: block;
 }
 .page-title {
   font-size: 220%;
-  color: #00a5e4;
+  color: #0206a8;
   font-weight: 700;
   padding-top: 10px;
   padding-bottom: 7px;
@@ -6939,7 +6945,7 @@ code {
   margin-top: -62px;
 }
 .member-collapsed {
-  background-color: #00a5e4;
+  background-color: #0206a8;
   color: #fac0ba;
 }
 .member-open {

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -34,7 +34,7 @@
 		<ul class="nav navbar-nav">
 			<?js this.nav.topLevelNav.forEach(function(entry){ ?>
 			<li class="dropdown">
-				<a href="<?js= entry.link ?>" class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
+				<a class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
 				<ul class="dropdown-menu <?js= that.navOptions.navType ==='inline' ? 'inline' : '' ?>">
 					<?js entry.members.forEach(function(member){ ?><li><?js= member ?></li><?js	}); ?>
 				</ul>

--- a/template-vanilla/publish.js
+++ b/template-vanilla/publish.js
@@ -64,7 +64,7 @@ var navigationMaster = {
   },
   namespace: {
     title: "Namespaces",
-    link: helper.getUniqueFilename("namespaces.list"),
+    // link: helper.getUniqueFilename("namespaces.list"),
     members: []
   },
   module: {

--- a/template-vanilla/static/styles/site.pdftron.css
+++ b/template-vanilla/static/styles/site.pdftron.css
@@ -1075,9 +1075,10 @@ body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
-  background-color: #FCFCFC;
-}
+  color: #000;
+  background-color: #fcfcfc;
+} 
+
 input,
 button,
 select,
@@ -1087,8 +1088,12 @@ textarea {
   line-height: inherit;
 }
 a {
-  color: #00a5e4;
+  color: #0206A8;
   text-decoration: none;
+}
+.subsection-title {
+  font-weight: 600;
+  color:#00083D;
 }
 a:hover,
 a:focus {
@@ -1177,7 +1182,7 @@ h6,
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 300;
   line-height: 1.1;
-  color: #444;
+  color: #000;
 }
 h1 small,
 h2 small,
@@ -1328,7 +1333,7 @@ mark,
   color: #808080;
 }
 .text-primary {
-  color: #00a5e4;
+  color: #0206a8;
 }
 a.text-primary:hover,
 a.text-primary:focus {
@@ -1364,7 +1369,7 @@ a.text-danger:focus {
 }
 .bg-primary {
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 a.bg-primary:hover,
 a.bg-primary:focus {
@@ -1553,7 +1558,7 @@ pre {
   line-height: 1.42857143;
   word-break: break-all;
   word-wrap: break-word;
-  color: #444;
+  color: #000;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -2490,7 +2495,7 @@ legend {
   margin-bottom: 18px;
   font-size: 19.5px;
   line-height: inherit;
-  color: #777;
+  color: #000;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
@@ -2534,7 +2539,7 @@ output {
   padding-top: 9px;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
+  color: #000;
 }
 .form-control {
   display: block;
@@ -2543,7 +2548,7 @@ output {
   padding: 8px 12px;
   font-size: 13px;
   line-height: 1.42857143;
-  color: #777;
+  color: #000;
   background-color: #fff;
   background-image: none;
   border: 1px solid #ddd;
@@ -3048,26 +3053,26 @@ fieldset[disabled] a.btn {
 }
 .btn-default {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:focus,
 .btn-default.focus {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:hover {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,
@@ -3079,8 +3084,8 @@ fieldset[disabled] a.btn {
 .btn-default.active.focus,
 .open > .dropdown-toggle.btn-default.focus {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-default:active,
 .btn-default.active,
@@ -3105,8 +3110,8 @@ fieldset[disabled] .btn-default.focus {
 }
 .btn-primary {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-primary:focus,
 .btn-primary.focus {
@@ -3153,11 +3158,11 @@ fieldset[disabled] .btn-primary:focus,
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 fieldset[disabled] .btn-primary.focus {
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .btn-primary .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .btn-success {
@@ -3389,7 +3394,7 @@ fieldset[disabled] .btn-danger.focus {
   background-color: #fff;
 }
 .btn-link {
-  color: #00a5e4;
+  color: #0206a8;
   font-weight: normal;
   border-radius: 0;
 }
@@ -3541,14 +3546,14 @@ tbody.collapse.in {
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;
-  color: #444;
+  color: #000;
   white-space: nowrap;
 }
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   text-decoration: none;
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
@@ -3556,7 +3561,7 @@ tbody.collapse.in {
   color: #fff;
   text-decoration: none;
   outline: 0;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
@@ -3886,7 +3891,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   font-size: 13px;
   font-weight: normal;
   line-height: 1;
-  color: #777;
+  color: #000;
   text-align: center;
   background-color: #ddd;
   border: 1px solid #ddd;
@@ -3990,7 +3995,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav .open > a:hover,
 .nav .open > a:focus {
   background-color: #ddd;
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .nav .nav-divider {
   height: 1px;
@@ -4020,7 +4025,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
-  color: #777;
+  color: #000;
   background-color: #FCFCFC;
   border: 1px solid #ddd;
   border-bottom-color: transparent;
@@ -4083,7 +4088,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {
   color: #fff;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .nav-stacked > li {
   float: none;
@@ -4261,6 +4266,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   font-size: 17px;
   line-height: 18px;
   height: 40px;
+  text-decoration: none;
 }
 .navbar-brand:hover,
 .navbar-brand:focus {
@@ -4480,34 +4486,34 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-color: #eeeeee;
 }
 .navbar-default .navbar-brand {
-  color: #777;
+  color: #0206a8;
 }
 .navbar-default .navbar-brand:hover,
 .navbar-default .navbar-brand:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-text {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-nav > li > a {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: transparent;
 }
 .navbar-default .navbar-nav > .disabled > a,
 .navbar-default .navbar-nav > .disabled > a:hover,
 .navbar-default .navbar-nav > .disabled > a:focus {
-  color: #444;
+  color: #000;
   background-color: transparent;
 }
 .navbar-default .navbar-toggle {
@@ -4528,51 +4534,51 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-default .navbar-nav > .open > a:hover,
 .navbar-default .navbar-nav > .open > a:focus {
   background-color: transparent;
-  color: #00a5e4;
+  color: #0206a8;
 }
 @media (max-width: 767px) {
   .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-    color: #777;
+    color: #000;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-    color: #00a5e4;
+    color: #0206a8;
     background-color: transparent;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
-    color: #00a5e4;
+    color: #0206a8;
     background-color: transparent;
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
-    color: #444;
+    color: #000;
     background-color: transparent;
   }
 }
 .navbar-default .navbar-link {
-  color: #777;
+  color: #000;
 }
 .navbar-default .navbar-link:hover {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .navbar-default .btn-link {
-  color: #777;
+  color: #000;
 }
 .navbar-default .btn-link:hover,
 .navbar-default .btn-link:focus {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .navbar-default .btn-link[disabled]:hover,
 fieldset[disabled] .navbar-default .btn-link:hover,
 .navbar-default .btn-link[disabled]:focus,
 fieldset[disabled] .navbar-default .btn-link:focus {
-  color: #444;
+  color: #000;
 }
 .navbar-inverse {
-  background-color: #00a5e4;
+  background-color: #0206a8;
   border-color: #a91b0c;
 }
 .navbar-inverse .navbar-brand {
@@ -4707,7 +4713,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   padding: 8px 12px;
   line-height: 1.42857143;
   text-decoration: none;
-  color: #444;
+  color: #000;
   background-color: #fff;
   border: 1px solid #ddd;
   margin-left: -1px;
@@ -4729,8 +4735,8 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > li > span:focus {
   z-index: 2;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .pagination > .active > a,
 .pagination > .active > span,
@@ -4740,8 +4746,8 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > .active > span:focus {
   z-index: 3;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
   cursor: default;
 }
 .pagination > .disabled > span,
@@ -4807,7 +4813,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pager li > a:hover,
 .pager li > a:focus {
   text-decoration: none;
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .pager .next > a,
 .pager .next > span {
@@ -4858,7 +4864,7 @@ a.label:focus {
   background-color: #2e2f2f;
 }
 .label-primary {
-  background-color: #00a5e4;
+  background-color: #0206a8;
 }
 .label-primary[href]:hover,
 .label-primary[href]:focus {
@@ -4903,7 +4909,7 @@ a.label:focus {
   vertical-align: middle;
   white-space: nowrap;
   text-align: center;
-  background-color: #00a5e4;
+  background-color: #0206a8;
   border-radius: 10px;
 }
 .badge:empty {
@@ -4926,7 +4932,7 @@ a.badge:focus {
 }
 .list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .list-group-item > .badge {
@@ -5001,11 +5007,11 @@ a.badge:focus {
 a.thumbnail:hover,
 a.thumbnail:focus,
 a.thumbnail.active {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .thumbnail .caption {
   padding: 9px;
-  color: #777;
+  color: #000;
 }
 .alert {
   padding: 15px;
@@ -5115,7 +5121,7 @@ a.thumbnail.active {
   line-height: 18px;
   color: #fff;
   text-align: center;
-  background-color: #00a5e4;
+  background-color: #0206a8;
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   -webkit-transition: width 0.6s ease;
@@ -5238,7 +5244,7 @@ a.thumbnail.active {
 }
 a.list-group-item,
 button.list-group-item {
-  color: #555;
+  color: #000;
 }
 a.list-group-item .list-group-item-heading,
 button.list-group-item .list-group-item-heading {
@@ -5249,7 +5255,7 @@ button.list-group-item:hover,
 a.list-group-item:focus,
 button.list-group-item:focus {
   text-decoration: none;
-  color: #555;
+  color: #000;
   background-color: #f5f5f5;
 }
 button.list-group-item {
@@ -5278,8 +5284,8 @@ button.list-group-item {
 .list-group-item.active:focus {
   z-index: 2;
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .list-group-item.active .list-group-item-heading,
 .list-group-item.active:hover .list-group-item-heading,
@@ -5660,7 +5666,7 @@ button.list-group-item-danger.active:focus {
   border-color: #ddd;
 }
 .panel-default > .panel-heading {
-  color: #444;
+  color: #000;
   background-color: #FCFCFC;
   border-color: #ddd;
 }
@@ -5669,28 +5675,28 @@ button.list-group-item-danger.active:focus {
 }
 .panel-default > .panel-heading .badge {
   color: #FCFCFC;
-  background-color: #444;
+  background-color: #000;
 }
 .panel-default > .panel-footer + .panel-collapse > .panel-body {
   border-bottom-color: #ddd;
 }
 .panel-primary {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .panel-primary > .panel-heading {
   color: #fff;
-  background-color: #00a5e4;
-  border-color: #00a5e4;
+  background-color: #0206a8;
+  border-color: #0206a8;
 }
 .panel-primary > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #00a5e4;
+  border-top-color: #0206a8;
 }
 .panel-primary > .panel-heading .badge {
-  color: #00a5e4;
+  color: #0206a8;
   background-color: #fff;
 }
 .panel-primary > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #00a5e4;
+  border-bottom-color: #0206a8;
 }
 .panel-success {
   border-color: #469408;
@@ -6727,7 +6733,7 @@ button.close {
 }
 .navbar-inverse .badge {
   background-color: #fff;
-  color: #00a5e4;
+  color: #0206a8;
 }
 .btn {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -6744,9 +6750,9 @@ button.close {
 }
 .btn-primary,
 .btn-primary:hover {
-  background-image: -webkit-linear-gradient(#e72510, #00a5e4 6%, #cb210e);
-  background-image: -o-linear-gradient(#e72510, #00a5e4 6%, #cb210e);
-  background-image: linear-gradient(#e72510, #00a5e4 6%, #cb210e);
+  background-image: -webkit-linear-gradient(#e72510, #0206a8 6%, #cb210e);
+  background-image: -o-linear-gradient(#e72510, #0206a8 6%, #cb210e);
+  background-image: linear-gradient(#e72510, #0206a8 6%, #cb210e);
   background-repeat: no-repeat;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe72510', endColorstr='#ffcb210e', GradientType=0);
   filter: none;
@@ -6796,10 +6802,10 @@ body {
   font-weight: 200;
 }
 th {
-  color: #444;
+  color: #000;
 }
 legend {
-  color: #444;
+  color: #000;
 }
 label {
   font-weight: normal;
@@ -6832,11 +6838,11 @@ label {
 .has-error.radio-inline label,
 .has-error.checkbox-inline label,
 .has-error .form-control-feedback {
-  color: #00a5e4;
+  color: #0206a8;
 }
 .has-error .form-control,
 .has-error .form-control:focus {
-  border-color: #00a5e4;
+  border-color: #0206a8;
 }
 .has-success .help-block,
 .has-success .control-label,
@@ -6856,11 +6862,11 @@ label {
   border-color: #469408;
 }
 .pager a {
-  color: #444;
+  color: #000;
 }
 .pager a:hover,
 .pager .active > a {
-  border-color: #00a5e4;
+  border-color: #0206a8;
   color: #fff;
 }
 .pager .disabled > a {
@@ -6907,20 +6913,20 @@ img.branding-logo {
 .copyright {
   font-size: 90%;
   text-align: center;
-  color: #00a5e4;
+  color: #0206a8;
   width: 100%;
   display: block;
 }
 .jsdoc-message {
   font-size: 90%;
   text-align: center;
-  color: #00a5e4;
+  color: #0206a8;
   width: 100%;
   display: block;
 }
 .page-title {
   font-size: 220%;
-  color: #00a5e4;
+  color: #0206a8;
   font-weight: 700;
   padding-top: 10px;
   padding-bottom: 7px;
@@ -6939,7 +6945,7 @@ code {
   margin-top: -62px;
 }
 .member-collapsed {
-  background-color: #00a5e4;
+  background-color: #0206a8;
   color: #fac0ba;
 }
 .member-open {

--- a/template-vanilla/tmpl/layout.tmpl
+++ b/template-vanilla/tmpl/layout.tmpl
@@ -32,7 +32,7 @@
 		<ul class="nav navbar-nav">
 			<?js this.nav.topLevelNav.forEach(function(entry){ ?>
 			<li class="dropdown">
-				<a href="<?js= entry.link ?>" class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
+				<a class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
 				<ul class="dropdown-menu <?js= that.navOptions.navType ==='inline' ? 'inline' : '' ?>">
 					<?js entry.members.forEach(function(member){ ?><li><?js= member ?></li><?js	}); ?>
 				</ul>


### PR DESCRIPTION
Issue:
the initial fixes comments out the link but there is a ternary operator in place see if there is a link and generate one if there is a link. This still creates 404 and the links. Commented out links are still requested from templates.

Changes:
The `tmpl` file that contains the dropdown, the `href` are removed. I ran the generate-docs with the changes in this repo and was able to remove all nav bar `href`. 

Test:
Replace the `layout.tmpl` file in webviewer jsdoc node_modules and remove the `npm i` in the generate-docs script. Then run the script. the index.html shouldn't have any references to those 404s in the nav bar except the Apyse WebViewer title.